### PR TITLE
Addresses flexibility issue raised in #3

### DIFF
--- a/ArchR_h5ad/_main/_Arrow.py
+++ b/ArchR_h5ad/_main/_Arrow.py
@@ -43,7 +43,7 @@ class _Arrow:
         
         self._use_matrix = use_matrix
         self._outpath = outpath
-        
+
         if not self._silent:
             mtx = licorice_font.font_format(self._use_matrix, ["BOLD", "BLUE"])
             print("Reading ArchR {} to AnnData".format(mtx))


### PR DESCRIPTION
- Non-standard human chromosomes are not parsed / merged into `adata` successfully. In theory, this rigidity is easy to replace.
- Raised by: #3